### PR TITLE
Add pyproject.toml to make an installable package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ __pycache__/
 .vscode/
 __pycache__/test_parse.cpython-311-pytest-8.0.2.pyc
 kml2ofds-testing.qgz
-
+dist/

--- a/README.md
+++ b/README.md
@@ -17,5 +17,48 @@ In broad strokes the script:
 * a node is then associated each with the "start" and "end" of each of the spans; and,
 * adds meta data to the spans and nodes. at the moment on the most basic meta data is added during the export process
 
+## Install kml2ofds
+
+### Using pipx
+
+The recommended way to install `kml2ofds` as a user is with [pipx][pipx].
+
+First ensure [pipx is installed](https://pipx.pypa.io/stable/#install-pipx), then to install the latest `kml2ofds`:
+
+```sh
+pipx install git+https://github.com/stevesong/kml2ofds.git@main
+```
+
+and then the command should be available to use (you may need to restart your shell):
+
+```sh
+kml2ofds [--options]
+```
+
+### Using pip
+
+To install `kml2ofds` inside an existing python virtual environment or conda environment:
+
+```sh
+# First activate your environment, then:
+pip install git+https://github.com/stevesong/kml2ofds.git@main
+```
+
+## Developing kml2ofds
+
+To test running `kml2ofds` while developing, it's necessary to install the package as editable using `pip -e`, e.g.:
+
+```sh
+cd path/to/kml2ofds/
+source .venv/bin/activate # If using a python virtual environment
+
+# Install as editable
+pip install -e .
+```
+
+To add, remove or update requirements, edit the dependencies section in `pyproject.toml`, then run `pip install -e .` again to update the dependencies in your virtual environment.
+
+
 [ofds-repo]: <https://github.com/Open-Telecoms-Data/open-fibre-data-standard>
 [ofds-docs]: <https://open-fibre-data-standard.readthedocs.io/en/latest/reference/schema.html>
+[pipx]: <https://github.com/pypa/pipx/>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,40 @@
+[project]
+name = "kml2ofds"
+version = "0.0.1"
+authors = [{ name = "Steve Song", email = "steve@manypossibilities.net" }]
+description = "KML2OFDS is a python script for converting KML maps of fibre optic network infrastructure to the Open Fibre Data Standard"
+readme = "README.md"
+
+# Minimum required version of python
+requires-python = ">=3.10"
+
+# Tool Dependencies
+dependencies = [
+    #"matplotlib==3.8.2",
+    "pykml ==0.2.0",
+    "numpy >=1.26.2, <2",
+    "shapely >=2.0.2, <3",
+    "geopandas >=0.14.1, <1.0",
+    "pandas >=2.1.3, <3",
+    "inquirer >=3.2.1, <4",
+    "click >=8.1, <9",
+    "libcoveofds == 0.9.0",
+]
+
+# License chosen from https://spdx.org/licenses/
+license = "GPL-3.0-or-later"
+
+# Classifiers from https://pypi.org/classifiers/
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Environment :: Console",
+    "Topic :: Scientific/Engineering :: GIS",
+]
+
+[project.scripts]
+# Install kml2ofds program to user's PATH
+kml2ofds = "kml2ofds:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"


### PR DESCRIPTION
This PR primarily adds `pyproject.toml` to enable this repo to be an installable project. This means the repo (or checked-out folder) is directly pip-installable.

The key thing to note with this change is that when a user installs this package, install dependencies are not defined by `requirements.txt`, but rather by the `dependencies` section of `pyproject.toml`, so `pyproject.toml` must be kept up to date if you add/remove/upgrade any dependencies.

It may be worth keeping `requirements.txt` around, for any extra dependencies you might want to use when developing or trying things out (perhaps renamed as `dev_requirements.txt`) such as matplotlib which i saw you've got commented out, but keep in mind that end-users will only have what's listed in `pyproject.toml` installed.

I've put together this dependency list by looking at what's imported by the script, and checking each library's release history and policy on semantic versioning, so where possible each version constraint will be at least the version that was specified in `requirements.txt` or an expected-to-be-compatible future version without breaking changes:

```toml
# Tool Dependencies
dependencies = [
    #"matplotlib==3.8.2",
    "pykml ==0.2.0",
    "numpy >=1.26.2, <2",
    "shapely >=2.0.2, <3",
    "geopandas >=0.14.1, <1.0",
    "pandas >=2.1.3, <3",
    "inquirer >=3.2.1, <4",
    "click >=8.1, <9",
    "libcoveofds == 0.9.0",
]
```
(excerpt from `pyproject.toml`)

I've left `matplotlib` in there commented out, in case you want to add it back in.

(I panicked a bit when I saw GDAL in requirements.txt, but calmed down when I saw it's not actually used!)

I've also updated the README with instructions on how an end-user can install the tool direct from the github repo, so we don't have to go through PyPi yet. I recommend `pipx` because it lets end-users install a python tool + dependencies in a self-contained virtual environment without polluting any global python environments, and it links the tool as an executable in the user's PATH so they can run it like any other command on their system. Plus pipx is made by PyPA themselves.

Note that the `pipx install` command in the README installs directly from the `main` branch of your repo, if you ever want to install a different branch or tag instead, change the name after `@` in the install URL. E.g. to test installing from this PR, the command would be: `pipx install git+https://github.com/R2ZER0/kml2ofds.git@rg/packaging`